### PR TITLE
Reorder generation operations to produce (hopefully) identical results to the Erlang code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,27 +1,27 @@
-DESTDIR ?= serialized
+DESTDIR ?= tmp
 SRCDIR ?= extern/hplans
 RESOLUTION ?= 7
 REGIONS ?= \
-  AS923-3  \
-  AS923-4  \
-  KR920    \
-  AS923-2  \
-  RU864    \
-  CN470    \
-  IN865    \
-  US915    \
-  EU433    \
-  AS923-1  \
+  AS923-1 \
   AS923-1B \
-  Unknown  \
-  AU915    \
-  EU868
+  AS923-2 \
+  AS923-3 \
+  AS923-4 \
+  AU915 \
+  CD900-1A \
+  CN470 \
+  EU433 \
+  EU868 \
+  IN865 \
+  KR920 \
+  RU864 \
+  US915
 
 TARGETS = $(patsubst %,$(DESTDIR)/%.res$(RESOLUTION).h3idx, $(REGIONS))
 SOURCES = $(patsubst %,$(SRCDIR)/%.GEOJSON, $(REGIONS))
 
 $(DESTDIR)/%.res$(RESOLUTION).h3idx: $(SRCDIR)/%.geojson
-	erl -pa _build/default/lib/*/ebin -noshell -eval "genh3:to_serialized_h3(\"$<\", \"$@\", $(RESOLUTION)), erlang:halt()"
+	./target/release/lw-generator generate $< $@
 
 all: $(TARGETS)
 

--- a/generator/src/main.rs
+++ b/generator/src/main.rs
@@ -68,9 +68,9 @@ fn sort_cells(mut cells: IndexVec<H3Cell>) -> Result<IndexVec<H3Cell>> {
         let ar = H3Cell::new(*a).resolution();
         let br = H3Cell::new(*b).resolution();
         if ar == br {
-            a.cmp(b)
+            Ordering::Equal
         } else {
-            ar.cmp(br)
+            ar.cmp(&br)
         }
     });
     Ok(cells)
@@ -118,8 +118,8 @@ impl Generate {
         read_geojson(&self.input)
             .and_then(|geojson| to_h3_cells(geojson, self.resolution))
             .and_then(dedup_cells)
-            .and_then(sort_cells)
             .and_then(compact_cells)
+            .and_then(sort_cells)
             .and_then(|cells| write_cells(cells, &self.output))
     }
 }


### PR DESCRIPTION
This also updates the makefile to use the new tool, so you can run these long-running operations in parallel using `make -j`.