### PR TITLE
Include last line of regions.txt

### DIFF
--- a/.github/workflows/region_maps.yml
+++ b/.github/workflows/region_maps.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Build | Matrix
         id: set-matrix
-        run: echo "matrix=$(cat regions.txt| jq -R -s -c 'split("\n")[:-1]')" >> $GITHUB_OUTPUT
+        run: echo "matrix=$(cat regions.txt| jq -R -s -c 'split("\n")')" >> $GITHUB_OUTPUT
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This fixes the missing US915 region map, but now requires that there is never an empty line at the end of regions.txt